### PR TITLE
Add support for _urls

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,6 +13,7 @@ For JSON formats conforming to [RFC 7159][], apply the following guidelines:
 
 1. JSON objects MAY include a `url` property to indicate a link to itself
 2. JSON objects MAY append `_url` to properties to indicate related links
+3. JSON objects MAY append `_urls` to properties to indicate an array of related links
 
 All URLs SHOULD conform to [RFC 3986][]. API providers MAY use camel case rather
 than snake case where applicable. A profile link conforming to [RFC 6906][], as
@@ -28,27 +29,29 @@ The JSON below shows a representation for an article.
 
 ``` json
 {
-    "url": "/articles/17",
-    "title": "Article Title",
-    "body": "The body of the article.",
-    "author_url": "/authors/42",
-    "categories": [
-        {
-            "url": "/categories/29",
-            "name": "Category A"
-        },
-        {
-            "url": "/categories/33",
-            "name": "Category B"
-        }
-    ],
-    "profile_url": "http://example.com/profile/article"
+  "url": "http://example.com/customers/777",
+  "first_name": "John",
+  "last_name": "Doe",
+  "orders": [
+    {
+      "url": "http://example.com/orders/23222",
+      "order_num": "43341",
+      "total": "398.55",
+      "currency": "USD",
+      "address_url": "http://example.com/addresses/337474",
+      "product_urls": [
+        "http://example.com/product/12359",
+        "http://example.com/product/3124",
+        "http://example.com/product/98351"
+      ]
+    }
+  ],
+  "profile_url": "http://example.com/profile/customer"
 }
 ```
 
-This example demonstrates using `url` in an article resource object and included 
-categories, associating a related author resource with an `author_url` link, and
-referencing documentation with a `docs_url` link.
+This example demonstrates using `url` in a customer resource object and included 
+`orders`. Each order has a linked address as `address_url` and linked products under `product_urls`. The `profile_url` links to more documentation for a customer resource.
 
 ## Usage and Guidelines
 


### PR DESCRIPTION
This PR adds support for `_urls`. It is currently a PR to start a discussion around the tradeoffs of adding this.

---

I believe this _might_ solve the issue for allowing people to link from one resource to many resources of the same type. Right now, this is not spelled out (as mentioned by #8), so it is left up to the producer to figure out how to do it and document it. I've listed out [some options](https://github.com/smizell/restfuljson/issues/8#issuecomment-358141155) before, but this PR focuses on the `_urls` option.

This approach to me is the most inline with the spirit of RESTful JSON. The intent of this spec was the be a stepping stone into the world of hypermedia. Most people are not thinking about hypermedia formats when designing an API, and to make a jump to something as simple as HAL is quite large. RESTful JSON's tagline even says, "Because adding links in JSON should be easy." Adding links to many resources of same type was not easy, and not something you could just add onto an existing design.

If you look at a library like Django REST Framework, you'll see that they sometimes will return an [array of IDs](http://www.django-rest-framework.org/api-guide/relations/#primarykeyrelatedfield). When using hyperlinks, they will return an [array of URIs](http://www.django-rest-framework.org/api-guide/relations/#hyperlinkedrelatedfield). Our goal has been to capture what people are already doing, and I think `_urls` fits that.

This also solves the issue I have run into with a collection resource. In order to provide pagination, you need to have some kind of collection resource which acts as a sort of wrapper around a list of related items. With `_urls`, you could not include a collection without including all of the items. But with this method, you can:

```
{
  "orders": {
    "next_url": "...",
    "previous_url": "...",
    "item_urls": [
      "...",
      "...",
      "...",
    ]
  }
}
```

Collection resources work just fine, both as embedded or as a standalone resource. But a collection resource is something you can migrate to later, because YAGNI. Yes, pagination and other patterns around a collection are great to consider up front, but with this, you don't _have_ to. A majority of people we are thinking about aren't thinking this way, so this could be of help to them.

Lastly, this adds support for producers to include more than one profile for their representations. I think this pushes us closer to being inline with the profile RFC, and lets RESTful JSON act as a strong bridge between pop culture REST and hypermedia REST.