### PR TITLE
Provide ready-made Markdown to copy-paste

### DIFF
--- a/index.md
+++ b/index.md
@@ -65,6 +65,14 @@ API providers SHOULD consider adding the note below to their documentation to de
 > to guide client interactions. Objects in this API MAY include a `url` property for a 
 > link to itself and MAY append `_url` to properties for related links.
 
+Ready-made Markdown:
+
+```markdown
+This API uses [RESTful JSON](http://restfuljson.org) by including links in the responses 
+to guide client interactions. Objects in this API MAY include a `url` property for a 
+link to itself and MAY append `_url` to properties for related links.
+```
+
 API providers SHOULD reference the documentation in a response.
 
 **At runtime**, only links a client is allowed to interact with SHOULD be present in API

--- a/index.md
+++ b/index.md
@@ -65,7 +65,7 @@ API providers SHOULD consider adding the note below to their documentation to de
 > to guide client interactions. Objects in this API MAY include a `url` property for a 
 > link to itself and MAY append `_url` to properties for related links.
 
-Ready-made Markdown:
+Ready-made [Markdown](https://en.wikipedia.org/wiki/Markdown):
 
 ```markdown
 This API uses [RESTful JSON](http://restfuljson.org) by including links in the responses 


### PR DESCRIPTION
This could be a little step to ease adoption, although I'm not sure how suitable it is for a "spec" document. Both API Blueprint and OpenAPI Spec support Markdown, so this could be useful for most API description format users. Also many documentations not based on API description formats could be written in Markdown.